### PR TITLE
 Incorporating argparse for command-line argument handling

### DIFF
--- a/data_processing/data_processing/face/process_data.py
+++ b/data_processing/data_processing/face/process_data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import csv
 import logging
 import os
@@ -224,10 +225,35 @@ def process_data(
 
 
 if __name__ == "__main__":
-    # Convert string arguments to boolean values
-    binary = sys.argv[3].lower() == "true"
-    get_frames = sys.argv[4].lower() == "true"
-    crop_images = sys.argv[5].lower() == "true"
+    parser = argparse.ArgumentParser(description="Process video data.")
+    parser.add_argument(
+        "video_dir", type=Path, help="Input directory containing videos."
+    )
+    parser.add_argument(
+        "output_path",
+        type=Path,
+        help="Output path where train/val/test directories will be created.",
+    )
+    parser.add_argument(
+        "-b", "--binary", action="store_true", help="Whether to use binary mode."
+    )
+    parser.add_argument(
+        "-f", "--get-frames", action="store_true", help="Whether to get frames."
+    )
+    parser.add_argument(
+        "-c", "--crop-images", action="store_true", help="Whether to crop images."
+    )
+    parser.add_argument(
+        "-l", "--log", action="store_true", help="Whether to log debug messages."
+    )
+    args = parser.parse_args()
 
-    # Call the function with converted boolean values
-    process_data(Path(sys.argv[1]), Path(sys.argv[2]), binary, get_frames, crop_images)
+    # Call the function with parsed arguments
+    process_data(
+        args.video_dir,
+        args.output_path,
+        args.binary,
+        args.get_frames,
+        args.crop_images,
+        args.log,
+    )

--- a/data_processing/data_processing/face/process_data.py
+++ b/data_processing/data_processing/face/process_data.py
@@ -224,7 +224,10 @@ def process_data(
     return output_path
 
 
-if __name__ == "__main__":
+def parse_args():
+    """
+    Parse command line arguments.
+    """
     parser = argparse.ArgumentParser(description="Process video data.")
     parser.add_argument(
         "video_dir", type=Path, help="Input directory containing videos."
@@ -246,7 +249,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-l", "--log", action="store_true", help="Whether to log debug messages."
     )
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
 
     # Call the function with parsed arguments
     process_data(

--- a/data_processing/data_processing/process_data.py
+++ b/data_processing/data_processing/process_data.py
@@ -23,7 +23,10 @@ def process_data(
     pupil.process_data(pupil_dir, plot_matlab, plot_result)
 
 
-if __name__ == "__main__":
+def parse_arguments():
+    """
+    Parse command line arguments.
+    """
     parser = argparse.ArgumentParser(description="Process video and pupil data.")
     parser.add_argument(
         "video_dir", type=Path, help="Input directory containing videos."
@@ -60,7 +63,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r", "--plot-result", action="store_true", help="Whether to plot results."
     )
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
 
     # Call the function with parsed arguments
     process_data(

--- a/data_processing/data_processing/process_data.py
+++ b/data_processing/data_processing/process_data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 from pathlib import Path
 import sys
 
@@ -23,4 +24,53 @@ def process_data(
 
 
 if __name__ == "__main__":
-    process_data(Path(sys.argv[1]), Path(sys.argv[1]), Path(sys.argv[2]))
+    parser = argparse.ArgumentParser(description="Process video and pupil data.")
+    parser.add_argument(
+        "video_dir", type=Path, help="Input directory containing videos."
+    )
+    parser.add_argument(
+        "output_path",
+        type=Path,
+        help="Output path where train/val/test directories will be created.",
+    )
+    parser.add_argument(
+        "pupil_dir", type=Path, help="Input directory containing pupil data."
+    )
+    parser.add_argument(
+        "-b",
+        "--binary-face",
+        action="store_true",
+        help="Whether to use binary face mode.",
+    )
+    parser.add_argument(
+        "-f", "--get-frames", action="store_true", help="Whether to get frames."
+    )
+    parser.add_argument(
+        "-c", "--crop-images", action="store_true", help="Whether to crop images."
+    )
+    parser.add_argument(
+        "-l", "--log", action="store_true", help="Whether to enable logging."
+    )
+    parser.add_argument(
+        "-m",
+        "--plot-matlab",
+        action="store_true",
+        help="Whether to plot the data with Matlab.",
+    )
+    parser.add_argument(
+        "-r", "--plot-result", action="store_true", help="Whether to plot results."
+    )
+    args = parser.parse_args()
+
+    # Call the function with parsed arguments
+    process_data(
+        args.video_dir,
+        args.output_path,
+        args.pupil_dir,
+        args.binary_face,
+        args.get_frames,
+        args.crop_images,
+        args.log,
+        args.plot_matlab,
+        args.plot_result,
+    )

--- a/data_processing/data_processing/pupil/process_data.py
+++ b/data_processing/data_processing/pupil/process_data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import csv
 from dataclasses import dataclass
 import numpy as np
@@ -128,6 +129,7 @@ def process_data(
     plot_matlab: bool = False,
     plot_result: bool = False,
 ):
+    # Start the matlab engine
     eng = matlab.engine.start_matlab()
     eng.addpath(str(Path(__file__).parent))
 
@@ -148,4 +150,22 @@ def process_data(
 
 
 if __name__ == "__main__":
-    process_data(Path(sys.argv[1]))
+    parser = argparse.ArgumentParser(description="Process data.")
+    parser.add_argument("data_dir", type=Path, help="Input directory containing data.")
+    parser.add_argument(
+        "-m",
+        "--plot-matlab",
+        action="store_true",
+        help="Whether to plot the data with Matlab.",
+    )
+    parser.add_argument(
+        "-r", "--plot-result", action="store_true", help="Whether to plot results."
+    )
+    args = parser.parse_args()
+
+    # Call the function with parsed arguments
+    process_data(
+        args.data_dir,
+        args.plot_matlab,
+        args.plot_result,
+    )

--- a/data_processing/data_processing/pupil/process_data.py
+++ b/data_processing/data_processing/pupil/process_data.py
@@ -149,7 +149,10 @@ def process_data(
     eng.quit()
 
 
-if __name__ == "__main__":
+def parse_args():
+    """
+    Parse command line arguments.
+    """
     parser = argparse.ArgumentParser(description="Process data.")
     parser.add_argument("data_dir", type=Path, help="Input directory containing data.")
     parser.add_argument(
@@ -161,7 +164,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r", "--plot-result", action="store_true", help="Whether to plot results."
     )
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
 
     # Call the function with parsed arguments
     process_data(


### PR DESCRIPTION
**Description**:
This Pull Request implements the use of `argparse` module for improved command-line argument handling in the project. `argparse` provides a convenient way to parse command-line arguments, making the project more user-friendly and robust.

**Changes Made**:
- Integrated `argparse` module to handle command-line arguments effectively.
- Added command-line options for various functionalities:
  - `-b` or `--binary-face` for enabling binary face mode.
  - `-f` or `--get-frames` for specifying whether to get frames.
  - `-c` or `--crop-images` for indicating whether to crop images.
  - `-l` or `--log` for enabling logging.
  - `-m` or `--plot-matlab` for plotting with Matlab.
  - `-r` or `--plot-result` for plotting results.
- Updated relevant functions to accept command-line arguments using `argparse`.
- If the flag is not set, the associated variable is `False`. This was the most intuitive solution (rather than integrating default values), and is not too complex given the shorthand versions of the flags.

**Testing Done**:
- Manually tested the script with various combinations of command-line arguments to ensure proper functionality and default values handling.
